### PR TITLE
do not build permutations for ancient internet explorer

### DIFF
--- a/gwt-boot-starters/gwt-boot-starter/src/main/resources/com/github/gwtboot/starter/Starter.gwt.xml
+++ b/gwt-boot-starters/gwt-boot-starter/src/main/resources/com/github/gwtboot/starter/Starter.gwt.xml
@@ -32,5 +32,5 @@
 	<super-source path="super"/>
 
 	<!-- Compiler agent -->
-	<set-property name="user.agent" value="ie8,ie9,ie10,gecko1_8,safari"/>
+	<set-property name="user.agent" value="gecko1_8,safari"/>
 </module>


### PR DESCRIPTION
Internet Explorer is recognized as gecko1_8 and ie10 and earlier are no longer supported by Microsoft since 2016